### PR TITLE
Bump x0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@compositor/x0": "^5.0.3",
+    "@compositor/x0": "^5.0.4",
     "react": "^16.4.0",
     "react-router-dom": "^4.2.2",
     "styled-components": "^3.3.0",


### PR DESCRIPTION
This fixes the issue where static HTML files in the current working directory (cwd) will override the dev server, making hot module replacement work in dev mode again